### PR TITLE
Fixed Readme heading formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-##OS MasterMap Topography Layer SQL & stylesheets
+## OS MasterMap Topography Layer SQL & stylesheets
 
 This repository contains database SQL scripts and cartographic stylesheets for styling OS MasterMap Topography Layer. Our hope is for this new method to become the standard way to post process the data so that styling OS MasterMap Topography Layer is far simpler and easier than before. It will also enable all of our customers and partners to utilise the released cartographic stylesheets.
 
-##Getting Started Guide
+## Getting Started Guide
 
 The Getting Started Guide is available in this repository and will help you apply the SQL and Stylesheets to your data.
 
-##Licence
+## Licence
 
 The contents of this repository are licensed under the [Open Government Licence 3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/)
 
 ![Logo](http://www.nationalarchives.gov.uk/images/infoman/ogl-symbol-41px-retina-black.png "OGL logo")
 
-##Partner Solutions
+## Partner Solutions
 
 **ESRI UK**
 


### PR DESCRIPTION
There needed to be a space in the headings after the `##`