### PR TITLE
Note about GeoServer SLDs with data in Oracle

### DIFF
--- a/Schema version 9/Stylesheets/Geoserver stylesheets (SLD)/README.md
+++ b/Schema version 9/Stylesheets/Geoserver stylesheets (SLD)/README.md
@@ -7,7 +7,11 @@ These are SLDs for OS MasterMap Topography Layer. You will need to apply the pos
 
 For help and advice please see the [Getting Started Guide](https://github.com/OrdnanceSurvey/OSMM-Topography-Layer-stylesheets/blob/master/Getting%20Started%20Guide%20-%20Styling%20OSMM%20Topography%20Layer.pdf)
 
-##Images
+### GeoServer and Oracle
+
+If using the SLDs in GeoServer with the data loaded into an Oracle database you may need to update all `<ogc:PropertyName>` values to be uppercase to match the data. Oracle column names are uppercase by default and an unquoted lowercase column name is treated as uppercase by the database.
+
+## Images
 
 ![Backdrop style](https://raw.githubusercontent.com/OrdnanceSurvey/OSMM-Topography-Layer-stylesheets/master/Schema%20version%209/Stylesheets/Geoserver%20stylesheets%20(SLD)/images/Backdrop-1.png)
 


### PR DESCRIPTION
I've been doing some work with OSMM Topo data in Oracle rendered via GeoServer recently. I found that the SLDs work just fine once I'd created the tables with uppercase column names (the default in Oracle) and I'd uppercased the `<ogc:PropertyName>` values to match.