### PR TITLE
Fixed mismatches between names in comments and in <FeatureTypeStyle><Rule><Name> elements

### DIFF
--- a/Schema version 9/Stylesheets/Geoserver stylesheets (SLD)/topographicarea-backdrop.sld
+++ b/Schema version 9/Stylesheets/Geoserver stylesheets (SLD)/topographicarea-backdrop.sld
@@ -71,7 +71,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Sand  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Foreshore - 1:0 to 1:4,000</Name>
+          <Name>Sand - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -91,7 +91,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Mud  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Foreshore - 1:0 to 1:4,000</Name>
+          <Name>Mud - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -111,7 +111,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Shingle  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Foreshore - 1:0 to 1:4,000</Name>
+          <Name>Shingle - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -507,7 +507,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Road Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Road Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -527,7 +527,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Rail Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Rail Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -547,7 +547,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -567,7 +567,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Footbridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Footbridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -587,7 +587,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Level Crossing  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Level Crossing - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -1021,7 +1021,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Saltmarsh -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Marsh - 1:0 to 1:4,000</Name>
+          <Name>Saltmarsh - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -1089,7 +1089,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Reeds -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Marsh - 1:0 to 1:4,000</Name>
+          <Name>Reeds - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -1123,7 +1123,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Canal  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Inland Water - 1:0 to 1:4,000</Name>
+          <Name>Canal - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>

--- a/Schema version 9/Stylesheets/Geoserver stylesheets (SLD)/topographicarea-light.sld
+++ b/Schema version 9/Stylesheets/Geoserver stylesheets (SLD)/topographicarea-light.sld
@@ -71,7 +71,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Sand  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Foreshore - 1:0 to 1:4,000</Name>
+          <Name>Sand - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -91,7 +91,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Mud  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Foreshore - 1:0 to 1:4,000</Name>
+          <Name>Mud - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -507,7 +507,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Road Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Road Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -527,7 +527,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Rail Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Rail Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -547,7 +547,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -567,7 +567,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Footbridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Footbridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -587,7 +587,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Level Crossing  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Level Crossing - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -1123,7 +1123,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Canal  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Inland Water - 1:0 to 1:4,000</Name>
+          <Name>Canal - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>

--- a/Schema version 9/Stylesheets/Geoserver stylesheets (SLD)/topographicarea-outdoor.sld
+++ b/Schema version 9/Stylesheets/Geoserver stylesheets (SLD)/topographicarea-outdoor.sld
@@ -71,7 +71,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Sand  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Foreshore - 1:0 to 1:4,000</Name>
+          <Name>Sand - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -91,7 +91,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Mud  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Foreshore - 1:0 to 1:4,000</Name>
+          <Name>Mud - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -507,7 +507,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Road Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Road Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -527,7 +527,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Rail Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Rail Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -547,7 +547,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -567,7 +567,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Footbridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Footbridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -587,7 +587,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Level Crossing  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Level Crossing - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -1021,7 +1021,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Saltmarsh -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Marsh - 1:0 to 1:4,000</Name>
+          <Name>Saltmarsh - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -1123,7 +1123,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Canal  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Inland Water - 1:0 to 1:4,000</Name>
+          <Name>Canal - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>

--- a/Schema version 9/Stylesheets/Geoserver stylesheets (SLD)/topographicarea-standard.sld
+++ b/Schema version 9/Stylesheets/Geoserver stylesheets (SLD)/topographicarea-standard.sld
@@ -71,7 +71,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Sand  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Foreshore - 1:0 to 1:4,000</Name>
+          <Name>Sand - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -91,7 +91,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Mud  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Foreshore - 1:0 to 1:4,000</Name>
+          <Name>Mud - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -111,7 +111,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Shingle  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Foreshore - 1:0 to 1:4,000</Name>
+          <Name>Shingle - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -491,7 +491,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Road Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Road Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -511,7 +511,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Rail Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Rail Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -531,7 +531,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Bridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Bridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -551,7 +551,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Footbridge  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Footbridge - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -571,7 +571,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Level Crossing  -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Structure - 1:0 to 1:4,000</Name>
+          <Name>Level Crossing - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>
@@ -611,7 +611,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       <!--  Agricultural Land -->
       <FeatureTypeStyle>
         <Rule>
-          <Name>Mixed Woodland - 1:0 to 1:4,000</Name>
+          <Name>Agricultural Land - 1:0 to 1:4,000</Name>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>style_code</ogc:PropertyName>


### PR DESCRIPTION
For example:

```
      <!--  Sand  -->
      <FeatureTypeStyle>
        <Rule>
          <Name>Foreshore - 1:0 to 1:4,000</Name>
          <ogc:Filter>
```

is replaced by:

```
      <!--  Sand  -->
      <FeatureTypeStyle>
        <Rule>
          <Name>Sand - 1:0 to 1:4,000</Name>
          <ogc:Filter>
```